### PR TITLE
support backtraces for files with absolute paths

### DIFF
--- a/lib/minitest/utils/reporter.rb
+++ b/lib/minitest/utils/reporter.rb
@@ -103,7 +103,7 @@ module Minitest
 
       def find_test_file(result)
         filter_backtrace(result.failure.backtrace)
-          .find {|line| line.match(%r(^(test|spec)/.*?_(test|spec).rb)) }
+          .find {|line| line.match(%r((test|spec)/.*?_(test|spec).rb)) }
           .gsub(/:\d+.*?$/, '')
       end
 


### PR DESCRIPTION
Hi,

For some reason, my backtraces have absolute paths in them.

Would you consider lessening the regular expression for matching a file?

Thanks,
Keenan
