### PR TITLE
Remove duplicated `Minitest::Utils::Reporter#statistics`.

### DIFF
--- a/lib/minitest/utils/reporter.rb
+++ b/lib/minitest/utils/reporter.rb
@@ -20,10 +20,6 @@ module Minitest
         @color_enabled = io.respond_to?(:tty?) && io.tty?
       end
 
-      def statistics
-        super
-      end
-
       def record(result)
         super
         print_result_code(result.result_code)


### PR DESCRIPTION
The method is already defined at https://github.com/fnando/minitest-utils/blob/v0.2.1/lib/minitest/utils/reporter.rb#L61-L64.
