### PR TITLE
Add a "start" banner similar to `Minitest::SummaryReporter#start`.

### DIFF
--- a/lib/minitest/utils/reporter.rb
+++ b/lib/minitest/utils/reporter.rb
@@ -25,6 +25,14 @@ module Minitest
         print_result_code(result.result_code)
       end
 
+      def start
+        super
+        io.puts "Run options: #{options[:args]}"
+        io.puts
+        io.puts "# Running:"
+        io.puts
+      end
+
       def report
         super
         io.sync = true


### PR DESCRIPTION
We now display the test suite run options, that includes the `seed` that was used to set the test order.

``` sh
$ bin/rake test
Run options: --seed 15295
```
