### PR TITLE
require 'mocha/mini_test' is deprecated, change to require 'mocha/minitest'

### DIFF
--- a/lib/minitest/utils.rb
+++ b/lib/minitest/utils.rb
@@ -15,7 +15,7 @@ module Minitest
       end
     end
 
-    load_lib.call "mocha/mini_test"
+    load_lib.call "mocha/minitest"
     load_lib.call "capybara"
 
     load_lib.call "webmock" do


### PR DESCRIPTION
This fixes a deprecation warning