### PR TITLE
Add support for I18n keyword arguments

### DIFF
--- a/lib/minitest/utils/rails.rb
+++ b/lib/minitest/utils/rails.rb
@@ -23,12 +23,12 @@ module ActiveSupport
 
     require "minitest/utils/rails/capybara" if defined?(Capybara)
 
-    def t(*args)
-      I18n.t(*args)
+    def t(*args, **kwargs)
+      I18n.t(*args, **kwargs)
     end
 
-    def l(*args)
-      I18n.l(*args)
+    def l(*args, **kwargs)
+      I18n.l(*args, **kwargs)
     end
   end
 end


### PR DESCRIPTION
This pull request adds support for keyword arguments to the I18n `t` and `l` functions.

Keyword arguments have been possible since ruby 3 and are used in the official documentation: https://guides.rubyonrails.org/i18n.html

Example code that causes issues in practice if I would use the `t` function:
https://github.com/dodona-edu/dodona/pull/4498/files#diff-0766148eceb8a6184a8e7a699244d5530c9c7356f76c836dbfa26d2ebae6266dR10

With the corresponding test:
https://github.com/dodona-edu/dodona/pull/4498/files#diff-dea6d8d9142890f588e2d37054543b932f1853e0936fbe34e0beedabd73bdeaeR11